### PR TITLE
Adding installer source

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+func main() {
+	fmt.Println("Checking environment")
+	basePath := os.Getenv("UserProfile")
+	if basePath == "" {
+		fmt.Println(" -- Couldn't resolve environment variables!")
+		return
+	}
+	fmt.Println("Found base path of: " + basePath)
+
+	fmt.Println("Verifying directories")
+	path := basePath + "/Documents/My Games/Path of Exile"
+	if !pathExists(path) {
+		fmt.Println(" -- Couldn't find a folder at " + path)
+		return
+	}
+	fmt.Println("Found PoE folder at: " + path)
+
+	fmt.Println("Reticulating splines")
+	filterName := "ThioleLootFilter"
+	filterURL := "https://raw.githubusercontent.com/icbat/LootFilter/master/" + filterName
+	fmt.Println("Grabbing " + filterName + " from: " + filterURL)
+	downloadTo(filterURL, path+"/"+filterName)
+
+	fmt.Println(`Done!
+
+	To finish the install:
+
+	1) Restart Path of Exile Beta if you have it open
+	2) Start game
+	3) Login to Beta
+	4) Esc > Options
+	5) GO to UI tab, at the bottom select the filter, once it says "Filter loaded successfully" no restart required, you are good to go
+	6) Any updates to the filter can be reloaded without restarting the game by clicking the "reload" button in options
+		`)
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
+func downloadTo(url string, targetFile string) {
+	response, getError := http.Get(url)
+	if getError != nil {
+		fmt.Println(" -- Couldn't GET: " + url)
+		return
+	}
+	defer response.Body.Close()
+
+	bytes, readError := ioutil.ReadAll(response.Body)
+	if readError != nil {
+		fmt.Println(" -- Couldn't read file at: " + url)
+		return
+	}
+
+	fileError := ioutil.WriteFile(targetFile, bytes, 0644)
+	if fileError != nil {
+		fmt.Println(" -- Couldn't write to file at: " + targetFile)
+		return
+	}
+}


### PR DESCRIPTION
Adding downloader source. Spent a while trying to get the git history to pull in, and gave up.

The repo I started in is https://github.com/icbat/poe-filter-finder

You can find a "release" with a built executable at https://github.com/icbat/poe-filter-finder/releases
