### PR TITLE
Change to show Talismans

### DIFF
--- a/leveling.filter
+++ b/leveling.filter
@@ -18,7 +18,10 @@ Show
 	
 Show 
 	Class "Quest Items"
-	
+
+Show
+    BaseType Talisman
+
 #####Shows better currency differently from lower currency for efficiency
 ##### skill gems
 Show


### PR DESCRIPTION
Used in the new league. They show up in the normal filter, but the white and blue ones weren't showing up here. This might be worth pulling over to the other files too, but this is the filter I'm using and noticed the miss.
